### PR TITLE
Add shelf filtering

### DIFF
--- a/src/main/java/com/example/shelfofshame/user/shelf/UserShelfItemController.java
+++ b/src/main/java/com/example/shelfofshame/user/shelf/UserShelfItemController.java
@@ -104,8 +104,8 @@ public class UserShelfItemController {
     @Operation(
             summary = "Retrieves a page of user shelf items",
             description = """
-                    Returns a paginated list of user shelf items belonging to the authenticated user.\s
-                    Pagination parameters (page and size) are passed as query parameters.\s"""
+                   Returns a paginated list of shelf items belonging to the authenticated user.
+                   Supports optional filtering by status, difficulty range, and genres."""
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Successfully retrieved a list of user shelf items"),
@@ -113,27 +113,31 @@ public class UserShelfItemController {
             @ApiResponse(responseCode = "500", description = "Internal server error")
     })
     @Parameters({
-            @Parameter(
-                    name = "page",
-                    description = "Page number (0-based)",
-                    in = ParameterIn.QUERY,
-                    schema = @Schema(type = "integer", defaultValue = "0")
-            ),
-            @Parameter(
-                    name = "size",
-                    description = "Number of items per page",
-                    in = ParameterIn.QUERY,
-                    schema = @Schema(type = "integer", defaultValue = "20")
-            )
+            @Parameter(name = "page", description = "Page number (0-based)", in = ParameterIn.QUERY,
+                    schema = @Schema(type = "integer", defaultValue = "0")),
+            @Parameter(name = "size", description = "Number of items per page", in = ParameterIn.QUERY,
+                    schema = @Schema(type = "integer", defaultValue = "20")),
+            @Parameter(name = "status", description = "Filter by item status", in = ParameterIn.QUERY,
+                    schema = @Schema(type = "string", allowableValues = {"SHAME", "GLORY", "READING"})),
+            @Parameter(name = "difficultyMin", description = "Minimum difficulty", in = ParameterIn.QUERY,
+                    schema = @Schema(type = "integer", minimum = "1", maximum = "10")),
+            @Parameter(name = "difficultyMax", description = "Maximum difficulty", in = ParameterIn.QUERY,
+                    schema = @Schema(type = "integer", minimum = "1", maximum = "10")),
+            @Parameter(name = "genres", description = "Comma-separated list of genres", in = ParameterIn.QUERY,
+                    schema = @Schema(type = "string"))
     })
     @SecurityRequirement(name = "bearerAuth")
     @GetMapping("/pages")
     public ResponseEntity<Page<UserShelfItemDto>> getUserShelfItemsPage(
             @Parameter(hidden = true) Principal principal,
-            Pageable pageable
+            Pageable pageable,
+            @RequestParam(required = false) Status status,
+            @RequestParam(required = false) Integer difficultyMin,
+            @RequestParam(required = false) Integer difficultyMax,
+            @RequestParam(required = false) List<String> genres
     ) {
         User user = authenticatedUserProvider.getCurrentUser(principal);
-        var page = userShelfItemService.findUserShelfItemsPage(user, pageable);
+        var page = userShelfItemService.findUserShelfItemsPage(user, pageable, status, difficultyMin, difficultyMax, genres);
         return ResponseEntity.ok(page);
     }
 

--- a/src/main/java/com/example/shelfofshame/user/shelf/UserShelfItemRepository.java
+++ b/src/main/java/com/example/shelfofshame/user/shelf/UserShelfItemRepository.java
@@ -5,12 +5,13 @@ import com.example.shelfofshame.user.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
 @Repository
-public interface UserShelfItemRepository extends JpaRepository<UserShelfItem, Long> {
+public interface UserShelfItemRepository extends JpaRepository<UserShelfItem, Long>, JpaSpecificationExecutor<UserShelfItem> {
     public List<UserShelfItem> findByUser(User user);
     public List<UserShelfItem> findByUserAndStatus(User user, Status status);
     public List<UserShelfItem> findByUserAndDifficulty(User user, int difficulty);

--- a/src/main/java/com/example/shelfofshame/user/shelf/UserShelfItemRepository.java
+++ b/src/main/java/com/example/shelfofshame/user/shelf/UserShelfItemRepository.java
@@ -4,6 +4,7 @@ import com.example.shelfofshame.book.Book;
 import com.example.shelfofshame.user.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
@@ -20,5 +21,5 @@ public interface UserShelfItemRepository extends JpaRepository<UserShelfItem, Lo
     public UserShelfItem findById(long id);
     public boolean existsByUserAndBook(User user, Book book);
     public boolean existsByUserAndId(User user, Long id);
-    public Page<UserShelfItem> findByUser(User user, Pageable pageable);
+    // public Page<UserShelfItem> findBy(Specification<UserShelfItem> specification, Pageable pageable);
 }

--- a/src/main/java/com/example/shelfofshame/user/shelf/UserShelfItemRepository.java
+++ b/src/main/java/com/example/shelfofshame/user/shelf/UserShelfItemRepository.java
@@ -2,9 +2,6 @@ package com.example.shelfofshame.user.shelf;
 
 import com.example.shelfofshame.book.Book;
 import com.example.shelfofshame.user.User;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
@@ -14,12 +11,6 @@ import java.util.List;
 @Repository
 public interface UserShelfItemRepository extends JpaRepository<UserShelfItem, Long>, JpaSpecificationExecutor<UserShelfItem> {
     public List<UserShelfItem> findByUser(User user);
-    public List<UserShelfItem> findByUserAndStatus(User user, Status status);
-    public List<UserShelfItem> findByUserAndDifficulty(User user, int difficulty);
-    public List<UserShelfItem> findByUserAndDifficultyAndStatus(User user, int difficulty, Status status);
-    public List<UserShelfItem> deleteByUserAndBook(User user, Book book);
-    public UserShelfItem findById(long id);
     public boolean existsByUserAndBook(User user, Book book);
     public boolean existsByUserAndId(User user, Long id);
-    // public Page<UserShelfItem> findBy(Specification<UserShelfItem> specification, Pageable pageable);
 }

--- a/src/main/java/com/example/shelfofshame/user/shelf/UserShelfItemService.java
+++ b/src/main/java/com/example/shelfofshame/user/shelf/UserShelfItemService.java
@@ -24,7 +24,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 

--- a/src/main/java/com/example/shelfofshame/user/shelf/UserShelfItemService.java
+++ b/src/main/java/com/example/shelfofshame/user/shelf/UserShelfItemService.java
@@ -18,6 +18,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -110,7 +111,13 @@ public class UserShelfItemService {
                 pageable.getPageSize(),
                 Sort.by(Sort.Direction.DESC, "id")
                 );
-        Page<UserShelfItem> items = userShelfItemRepository.findByUser(user, sortedPageable);
+        Specification<UserShelfItem> specification = Specification.where(UserShelfItemSpecs.belongsToUser(user));
+
+        if(status != null) specification = specification.and(UserShelfItemSpecs.hasStatus(status));
+        if(min != null || max != null) specification = specification.and(UserShelfItemSpecs.hasDifficulty(min, max));
+        if(genres != null && !genres.isEmpty()) specification = specification.and(UserShelfItemSpecs.genresIn(genres));
+
+        Page<UserShelfItem> items = userShelfItemRepository.findAll(specification, sortedPageable);
         return items.map(userShelfItemMapper::toUserShelfItemDto);
     }
 

--- a/src/main/java/com/example/shelfofshame/user/shelf/UserShelfItemService.java
+++ b/src/main/java/com/example/shelfofshame/user/shelf/UserShelfItemService.java
@@ -104,11 +104,11 @@ public class UserShelfItemService {
     }
 
     @Transactional(readOnly = true)
-    public Page<UserShelfItemDto> findUserShelfItemsPage(User user, Pageable pageable) {
+    public Page<UserShelfItemDto> findUserShelfItemsPage(User user, Pageable pageable, Status status, Integer min, Integer max, List<String> genres) {
         Pageable sortedPageable = PageRequest.of(
                 pageable.getPageNumber(),
                 pageable.getPageSize(),
-                Sort.by(Sort.Direction.ASC, "id")
+                Sort.by(Sort.Direction.DESC, "id")
                 );
         Page<UserShelfItem> items = userShelfItemRepository.findByUser(user, sortedPageable);
         return items.map(userShelfItemMapper::toUserShelfItemDto);

--- a/src/main/java/com/example/shelfofshame/user/shelf/UserShelfItemSpecs.java
+++ b/src/main/java/com/example/shelfofshame/user/shelf/UserShelfItemSpecs.java
@@ -1,21 +1,30 @@
 package com.example.shelfofshame.user.shelf;
 
+import com.example.shelfofshame.user.User;
 import org.springframework.data.jpa.domain.Specification;
 
 import java.util.List;
 
 public class UserShelfItemSpecs {
-    public Specification<UserShelfItem> hasStatus(Status status) {
+    public static Specification<UserShelfItem> hasStatus(Status status) {
         return (root, query, builder) -> builder.equal(root.get("status"), status);
     }
 
-    public Specification<UserShelfItem> hasDifficulty(Integer minDifficulty, Integer maxDifficulty) {
+    public static Specification<UserShelfItem> hasDifficulty(Integer minDifficulty, Integer maxDifficulty) {
         int min = minDifficulty == null ? 1 : minDifficulty;
         int max = maxDifficulty == null ? 10 : maxDifficulty;
         return (root, query, builder) -> builder.between(root.get("difficulty"), min, max);
     }
 
-    public Specification<UserShelfItem> genresIn(List<String> genres) {
-        return (root, query, builder) -> root.join("genres").get("name").in(genres);
+    public static Specification<UserShelfItem> genresIn(List<String> genres) {
+        return (root, query, builder) -> {
+            query.distinct(true);
+            return root.join("genres").get("name").in(genres);
+        };
+
+    }
+
+    public static Specification<UserShelfItem> belongsToUser(User user) {
+        return (root, query, builder) -> builder.equal(root.get("user"), user);
     }
 }

--- a/src/main/java/com/example/shelfofshame/user/shelf/UserShelfItemSpecs.java
+++ b/src/main/java/com/example/shelfofshame/user/shelf/UserShelfItemSpecs.java
@@ -1,0 +1,21 @@
+package com.example.shelfofshame.user.shelf;
+
+import org.springframework.data.jpa.domain.Specification;
+
+import java.util.List;
+
+public class UserShelfItemSpecs {
+    public Specification<UserShelfItem> hasStatus(Status status) {
+        return (root, query, builder) -> builder.equal(root.get("status"), status);
+    }
+
+    public Specification<UserShelfItem> hasDifficulty(Integer minDifficulty, Integer maxDifficulty) {
+        int min = minDifficulty == null ? 1 : minDifficulty;
+        int max = maxDifficulty == null ? 10 : maxDifficulty;
+        return (root, query, builder) -> builder.between(root.get("difficulty"), min, max);
+    }
+
+    public Specification<UserShelfItem> genresIn(List<String> genres) {
+        return (root, query, builder) -> root.join("genres").get("name").in(genres);
+    }
+}

--- a/src/main/java/com/example/shelfofshame/user/shelf/UserShelfItemSpecs.java
+++ b/src/main/java/com/example/shelfofshame/user/shelf/UserShelfItemSpecs.java
@@ -19,7 +19,11 @@ public class UserShelfItemSpecs {
     public static Specification<UserShelfItem> genresIn(List<String> genres) {
         return (root, query, builder) -> {
             query.distinct(true);
-            return root.join("genres").get("name").in(genres);
+            return root
+                    .join("book")
+                    .join("genres")
+                    .get("name")
+                    .in(genres);
         };
 
     }


### PR DESCRIPTION
I've introduced filtering functionality to my API by leveraging JPA Specifications.
Filtering options:
- by status (all by default)
- by genres (all by default
- by difficulty range (1-10 by default)
Or any above combination.
Adjusting to JPA Specifications required UserShelfItem repository tweaking and cleanup. 